### PR TITLE
change installation command for npm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ bun add -D jason
 
 # or
 
-npm install -D jason
+npm i @aurios/jason
 ```
 
 ## 💻 Quick Example


### PR DESCRIPTION
# Description

The valid address of library on npm is https://www.npmjs.com/package/@aurios/jason 

So you need type `npm i @aurios/jason` to use it via npm.

## Type of change

Documentation update

## Related Issue

No.

## How Has This Been Tested?

Via `npm install`.
